### PR TITLE
DEVX-2268: The schema registry listener should be explicitly defined,…

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     hostname: schema-registry
     container_name: schema-registry
     ports:
-      - '8085:8085'
+      - '8081:8081'
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8085
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
       SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: "SASL_SSL"
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: $BOOTSTRAP_SERVERS
       SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
     image: cnfldemos/kafka-connect-datagen:0.4.0-6.0.0

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
     image: cnfldemos/cp-server-connect-datagen:0.4.0-6.0.0


### PR DESCRIPTION
… as changing the port will break SR if the listener is not provided

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2268

_What behavior does this PR change, and why?_

User was building a demo environment based on cp-all-in-one. In their env, they modified the ports for several components. Upon starting the env, SR was not available and it wasn't obvious why. By explicitly defining the listener for SR, even though it defaults to listening on the default port, users will likely deduce they need to update the listener when changing the default port numbers.


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
- [x] cp-all-in-one
- [x] cp-all-in-one-cloud
- [x] cp-all-in-one-community


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

Just code review.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
