### PR TITLE
template-for-issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Description**
+A clear and concise description of what the issue is.
 
 **Troubleshooting**
 If applicable, please include the output of `docker-compose logs <container name>`.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ A clear and concise description of what the bug is.
 **Troubleshooting**
 If applicable, please include the output of `docker-compose logs <container name>`.
 
-**Envirnonment**
- - GitHub branch: [e.g. 6.0.1-post, etc]
+**Environment**
+ - GitHub branch: [e.g. `6.0.1-post`, etc]
  - Operating System
  - Version of Docker
  - Version of Docker Compose

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Troubleshooting**
+If applicable, please include the output of `docker-compose logs <container name>`.
+
+**Envirnonment**
+ - GitHub branch: [e.g. 6.0.1-post, etc]
+ - Operating System
+ - Version of Docker
+ - Version of Docker Compose

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,10 +11,12 @@ assignees: ''
 A clear and concise description of what the issue is.
 
 **Troubleshooting**
-If applicable, please include the output of `docker-compose logs <container name>`.
+If applicable, please include the output of:
+ - `docker-compose logs <container name>`
+ - any other relevant commands
 
 **Environment**
  - GitHub branch: [e.g. `6.0.1-post`, etc]
- - Operating System
- - Version of Docker
- - Version of Docker Compose
+ - Operating System:
+ - Version of Docker:
+ - Version of Docker Compose:


### PR DESCRIPTION
Introduce template for new GitHub issues.  Once we review/approve this one, we can port over to the other GH repos