### PR TITLE
DEVX-2314: Update all links from GH repos to docs.confluent.io: full path has changed with docs migration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html)

--- a/cp-all-in-one-cloud/README.md
+++ b/cp-all-in-one-cloud/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html).
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)

--- a/cp-all-in-one-cloud/README.md
+++ b/cp-all-in-one-cloud/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html).

--- a/cp-all-in-one-community/README.md
+++ b/cp-all-in-one-community/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html).
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)

--- a/cp-all-in-one-community/README.md
+++ b/cp-all-in-one-community/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html).

--- a/cp-all-in-one/README.md
+++ b/cp-all-in-one/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)

--- a/cp-all-in-one/README.md
+++ b/cp-all-in-one/README.md
@@ -2,4 +2,4 @@
   
 # Documentation
 
-You can find the documentation and instructions for this repo at [https://docs.confluent.io/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/current/tutorials/build-your-own-demos.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.cp-all-in-one)
+You can find the documentation and instructions for this repo at [https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html](https://docs.confluent.io/platform/current/tutorials/build-your-own-demos.html)

--- a/utils/ccloud-generate-cp-configs.sh
+++ b/utils/ccloud-generate-cp-configs.sh
@@ -44,7 +44,7 @@
 #
 # Documentation for using this script:
 #
-#   https://docs.confluent.io/current/cloud/connect/auto-generate-configs.html
+#   https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs
 #
 # Arguments:
 #
@@ -75,7 +75,7 @@ if [[ -z "$CONFIG_FILE" ]]; then
 fi
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "File $CONFIG_FILE is not found.  Please create this properties file to connect to your Confluent Cloud cluster and then try again"
-  echo "See https://docs.confluent.io/current/cloud/connect/auto-generate-configs.html for more information"
+  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs for more information"
   exit 1
 fi
 echo "CONFIG_FILE: $CONFIG_FILE"
@@ -86,7 +86,7 @@ if [[ -z "$SR_CONFIG_FILE" ]]; then
 fi
 if [[ ! -f "$SR_CONFIG_FILE" ]]; then
   echo "File $SR_CONFIG_FILE is not found.  Please create this properties file to connect to your Schema Registry and then try again"
-  echo "See https://docs.confluent.io/current/cloud/connect/auto-generate-configs.html for more information"
+  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs for more information"
   exit 1
 fi
 echo "SR_CONFIG_FILE: $SR_CONFIG_FILE"

--- a/utils/ccloud-generate-cp-configs.sh
+++ b/utils/ccloud-generate-cp-configs.sh
@@ -44,7 +44,7 @@
 #
 # Documentation for using this script:
 #
-#   https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs
+#   https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html
 #
 # Arguments:
 #
@@ -75,7 +75,7 @@ if [[ -z "$CONFIG_FILE" ]]; then
 fi
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "File $CONFIG_FILE is not found.  Please create this properties file to connect to your Confluent Cloud cluster and then try again"
-  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs for more information"
+  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html for more information"
   exit 1
 fi
 echo "CONFIG_FILE: $CONFIG_FILE"
@@ -86,7 +86,7 @@ if [[ -z "$SR_CONFIG_FILE" ]]; then
 fi
 if [[ ! -f "$SR_CONFIG_FILE" ]]; then
   echo "File $SR_CONFIG_FILE is not found.  Please create this properties file to connect to your Schema Registry and then try again"
-  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html#auto-generate-configs for more information"
+  echo "See https://docs.confluent.io/cloud/current/cp-component/auto-generate-configs.html for more information"
   exit 1
 fi
 echo "SR_CONFIG_FILE: $SR_CONFIG_FILE"


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2314
_What behavior does this PR change, and why?_
Update links to map to full path in docs. I found the docs links by using grep -R " https://docs.confluent.io/current" .. Please note if you think that is not sufficient.

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
- [x] Documentation --> in `utils/ccloud-generate-cp-configs.sh`


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation --> in `utils/ccloud-generate-cp-configs.sh`
