### PR TITLE
DEVX-2374 and DEVX-2372: Update CLASSPATH and datagen CP versions

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.connect.local.yml
+++ b/cp-all-in-one-cloud/docker-compose.connect.local.yml
@@ -30,7 +30,7 @@ services:
       CONNECT_LOG4J_ROOT_LOGLEVEL: INFO
       CONNECT_LOG4J_LOGGERS: org.reflections=ERROR
       # CLASSPATH required due to CC-2422
-      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-6.0.1.jar
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-6.1.0.jar
       # Connect worker
       CONNECT_SECURITY_PROTOCOL: SASL_SSL
       CONNECT_SASL_JAAS_CONFIG: $SASL_JAAS_CONFIG

--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       PORT: 9021
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.4.0-6.0.1
+    image: cnfldemos/cp-server-connect-datagen:0.4.0-6.1.0
     hostname: connect
     container_name: connect
     ports:

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.4.0-6.0.1
+    image: cnfldemos/kafka-connect-datagen:0.4.0-6.1.0
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.4.0-6.0.1
+    image: cnfldemos/cp-server-connect-datagen:0.4.0-6.1.0
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
### Description 

https://confluentinc.atlassian.net/browse/DEVX-2372
https://confluentinc.atlassian.net/browse/DEVX-2374

_What behavior does this PR change, and why?_
This PR covers updating all necessary version numbers to the latest CP and datagen version. All but one of the CLASSPATH reference was already updated to the latest CP version number. Updated the datagen references to the latest published images. 

Tested cp-all-in-one and cp-all-in-one-community. Was able to submit json to the connector (pageviews and users) and see the corresponding data flow [used these instructions](https://docs.confluent.io/platform/current/quickstart/cos-docker-quickstart.html).

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [x] cp-all-in-one
 - [ ] cp-all-in-one-cloud 
 - [x] cp-all-in-one-community


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._
Not sure if the reviewer would like to test a different cp-all-in-one 🤷‍♀️ 
<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [ ] cp-all-in-one
 - [ ] cp-all-in-one-cloud 
 - [ ] cp-all-in-one-community
