### PR TITLE
Un hard-coded confluentinc as connector owner, replaced with build-arg

### DIFF
--- a/Docker-connect/distributed/Dockerfile
+++ b/Docker-connect/distributed/Dockerfile
@@ -17,6 +17,7 @@ FROM confluentinc/cp-server-connect-base:6.2.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 
+ARG CONNECTOR_OWNER=confluentinc
 ARG CONNECTOR_NAME
 ARG CONNECTOR_VERSION
-RUN confluent-hub install --no-prompt confluentinc/${CONNECTOR_NAME}:${CONNECTOR_VERSION}
+RUN confluent-hub install --no-prompt ${CONNECTOR_OWNER}/${CONNECTOR_NAME}:${CONNECTOR_VERSION}

--- a/Docker-connect/standalone/Dockerfile
+++ b/Docker-connect/standalone/Dockerfile
@@ -21,8 +21,9 @@ USER root
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 USER appuser
 
+ARG CONNECTOR_OWNER=confluentinc
 ARG CONNECTOR_NAME
 ARG CONNECTOR_VERSION
-RUN confluent-hub install --no-prompt confluentinc/${CONNECTOR_NAME}:${CONNECTOR_VERSION}
+RUN confluent-hub install --no-prompt ${CONNECTOR_OWNER}/${CONNECTOR_NAME}:${CONNECTOR_VERSION}
 
 CMD ["/etc/confluent/docker/run"]


### PR DESCRIPTION
### Description 

Currently `confluentinc` is assumed as the connector owner and is hard-coded in the two `Dockerfile`s that build the local Connect image with a connector installed.

This allows installation of non-Confluent owned/namespaced connectors from Confluent Hub into
the Connect local image.  For example, by setting:

```
   --build-arg CONNECTOR_OWNER=${CONNECTOR_OWNER} \
```

... with `CONNECTOR_OWNER=splunk` environment set, I can install:

```
splunk/kafka-connect-splunk:2.0.2
```

~~Doc changes required and pending initial review of PR.~~

Docs: https://github.com/confluentinc/docs-platform/pull/975

### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

~~Doc changes would be required, pending a positive initial review of this PR.~~

Docs: https://github.com/confluentinc/docs-platform/pull/975

<!-- Uncomment any of the following that are required -->
- [X] Documentation -->
- [X] cp-all-in-one-cloud -->

### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
- [ ] Documentation -->
- [ ] cp-all-in-one-cloud -->
