### PR TITLE
Fixed update_run.sh path and permission

### DIFF
--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
     volumes:
       - ${PWD}/update_run.sh:/tmp/update_run.sh
-    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else chmod +x /tmp/update_run.sh && /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.0.0

--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
     volumes:
-      - ./update_run.sh:/tmp/update_run.sh
-    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
+      - ${PWD}/update_run.sh:/tmp/update_run.sh
+    command: "bash -c 'if [ ! -f /tmp/update_run.sh ]; then echo \"ERROR: Did you forget the update_run.sh file that came with this docker-compose.yml file?\" && exit 1 ; else chmod +x /tmp/update_run.sh && /tmp/update_run.sh && /etc/confluent/docker/run ; fi'"
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.0.0


### PR DESCRIPTION
Wouldn't start on my Mac, probably needs the absolute path to the file

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

Fixed path to update_run.sh (couldn't mount the relative path)
Permissions fix when run the script


### Author Validation

After this fix `docker-compose up`  starts correct.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
- [ ] cp-all-in-one-kraft


### Reviewer Tasks

Test if `docker-compose up` still starts

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
- [ ] cp-all-in-one-kraft
