### PR TITLE
upgrade datagen connector image to be based on CP 7.2.1

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       PORT: 9021
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.2.1
     hostname: connect
     container_name: connect
     ports:

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/kafka-connect-datagen:0.5.3-7.2.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.2.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.2.1
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

Update datagen connect image to be based off of CP 7.2.1


### Author Validation

Smoke tested against cp-quickstart's:

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [x] cp-all-in-one
 - [x] cp-all-in-one-community
 - [x] cp-all-in-one-kraft


### Reviewer Tasks

Code review
Smoke test if desired

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->
