### PR TITLE
use --cluster-id flag to accommodate 'kafka-storage random-uuid' output that's dash-prefixed

### DIFF
--- a/cp-all-in-one-kraft/update_run.sh
+++ b/cp-all-in-one-kraft/update_run.sh
@@ -7,4 +7,4 @@ sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure
 sed -i 's/cub zk-ready/echo ignore zk-ready/' /etc/confluent/docker/ensure
 
 # KRaft required step: Format the storage directory with a new cluster ID
-echo "kafka-storage format --ignore-formatted -t $(kafka-storage random-uuid) -c /etc/kafka/kafka.properties" >> /etc/confluent/docker/ensure
+echo "kafka-storage format --ignore-formatted --cluster-id=$(kafka-storage random-uuid) -c /etc/kafka/kafka.properties" >> /etc/confluent/docker/ensure


### PR DESCRIPTION
## Problem

Occasionally, the `kafka-storage random-uuid` command outputs a `-` prefixed string, which causes the `kafka-storage format` command to fail. An example of this (which we recently saw in CI) was the string `-f_5rGTAQYmTztSSUAVNuQ`.

## Solution

The `--cluster-id` flag doesn't have the same limitations w/respect to dash-prefixed cluster ids as `-t` does, so use that.