### PR TITLE
DEVX-2761: upgrade to multiarch datagen connect worker image

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       PORT: 9021
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.6.0-7.2.1
     hostname: connect
     container_name: connect
     ports:

--- a/cp-all-in-one-community/docker-compose.yml
+++ b/cp-all-in-one-community/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/kafka-connect-datagen:0.6.0-7.2.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.6.0-7.2.1
     hostname: connect
     container_name: connect
     depends_on:

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: cnfldemos/cp-server-connect-datagen:0.6.0-7.2.1
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
The latest image has arm64 support so that cp-all-in-one will work on M1 MacBooks.

### Description 

https://confluentinc.atlassian.net/browse/DEVX-2761

_Upgrade all cp-all-in-one docker-compose.yml files to use the latest multiarch datagen connect worker image. Notably, this image has arm64 (Apple M1) support._



### Author Validation

Validated that the examples continue to work on amd64. Prior to merging, will ask an eng w/ M1 to validate.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [x] cp-all-in-one
 - [x] cp-all-in-one-cloud
 - [x] cp-all-in-one-community
 - [x] cp-all-in-one-kraft


### Reviewer Tasks

_Optionally smoke test w/ cp-quickstart._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->
