### PR TITLE
Update docker-compose.yml to fix connect

### DIFF
--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.5.3-7.1.0
+    image: confluentinc/cp-kafka-connect:7.4.0
     hostname: connect
     container_name: connect
     depends_on:
@@ -115,6 +115,7 @@ services:
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
       CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER: 'connect:8083'
+      CONTROL_CENTER_CONNECT_HEALTHCHECK_ENDPOINT: '/connectors'
       CONTROL_CENTER_KSQL_KSQLDB1_URL: "http://ksqldb-server:8088"
       CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL: "http://localhost:8088"
       CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"

--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: confluentinc/cp-kafka-connect:7.4.0
+    image: cnfldemos/cp-server-connect-datagen:0.6.0-7.3.0
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
There was an issue in the current version where due to using a different image for the connect service and also missing the       CONTROL_CENTER_CONNECT_HEALTHCHECK_ENDPOINT: '/connectors' parameter, the connect cluster would not show up in c3. This PR adds these changes to make the connect cluster appear in c3

### Description 

<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->
