### PR TITLE
Making C3 version configurable

### DIFF
--- a/cp-all-in-one-kraft/docker-compose.yml
+++ b/cp-all-in-one-kraft/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
   prometheus:
-    image: confluentinc/cp-enterprise-prometheus:2.0.0
+    image: confluentinc/cp-enterprise-prometheus:${C3_VERSION:-2.0.0}
     hostname: cp-enterprise-prometheus
     container_name: prometheus
     volumes:
@@ -94,7 +94,7 @@ services:
     command: "--config.file=/mnt/config/prometheus.yml --enable-feature=otlp-write-receiver --web.enable-lifecycle"
 
   alertmanager:
-    image: confluentinc/cp-enterprise-alertmanager:2.0.0
+    image: confluentinc/cp-enterprise-alertmanager:${C3_VERSION:-2.0.0}
     hostname: cp-enterprise-alertmanager
     container_name: alertmanager
     depends_on:
@@ -106,7 +106,7 @@ services:
     command: "--web.external-url=http://localhost --config.file=/etc/alertmanager/alertmanager.yml"
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center-next-gen:2.0.0
+    image: confluentinc/cp-enterprise-control-center-next-gen:${C3_VERSION:-2.0.0}
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/cp-all-in-one/README.md
+++ b/cp-all-in-one/README.md
@@ -1,6 +1,58 @@
 ![image](../images/confluent-logo-300-2.png)
   
-# Documentation
+# Confluent Platform All-in-One
+
+This Docker Compose setup provides a complete Confluent Platform environment with Control Center, Prometheus, and Alertmanager monitoring.
+
+## Quick Start
+
+### Default Setup
+```bash
+docker-compose up -d
+```
+
+### Custom Control Center Version
+You can specify the Control Center version using the `C3_VERSION` environment variable:
+
+```bash
+# For Control Center version 2.1.0
+C3_VERSION=2.1.0 docker-compose up -d
+
+# For Control Center version 2.0.0 (default)
+C3_VERSION=2.0.0 docker-compose up -d
+```
+
+## Supported Versions
+
+The following Control Center versions are supported:
+- `2.0.0` (default)
+- `2.1.0`
+
+## Services
+
+- **Kafka Broker**: `localhost:9092`
+- **Control Center**: `localhost:9021`
+- **Schema Registry**: `localhost:8081`
+- **Kafka Connect**: `localhost:8083`
+- **ksqlDB**: `localhost:8088`
+- **Prometheus**: `localhost:9090`
+- **Alertmanager**: `localhost:9093`
+
+## Environment Variables
+
+- `C3_VERSION`: Control Center version (default: `2.0.0`)
+
+## Usage Examples
+
+```bash
+# Start with default version (2.0.0)
+docker-compose up -d
+
+# Start with version 2.1.0
+C3_VERSION=2.1.0 docker-compose up -d
+```
+
+## Documentation
 
 Refer to the [Quick Start for Confluent Platform](https://docs.confluent.io/platform/current/get-started/platform-quickstart.html) for steps to run this example.
 

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
   prometheus:
-    image: confluentinc/cp-enterprise-prometheus:2.0.0
+    image: confluentinc/cp-enterprise-prometheus:${C3_VERSION:-2.0.0}
     hostname: cp-enterprise-prometheus
     container_name: prometheus
     volumes:
@@ -107,7 +107,7 @@ services:
 
 
   alertmanager:
-    image: confluentinc/cp-enterprise-alertmanager:2.0.0
+    image: confluentinc/cp-enterprise-alertmanager:${C3_VERSION:-2.0.0}
     hostname: cp-enterprise-alertmanager
     container_name: alertmanager
     depends_on:
@@ -122,7 +122,7 @@ services:
 
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center-next-gen:2.0.0
+    image: confluentinc/cp-enterprise-control-center-next-gen:${C3_VERSION:-2.0.0}
     hostname: control-center
     container_name: control-center
     depends_on:


### PR DESCRIPTION
### Description 
Added `C3_VERSION` to support both `2.0.0` and `2.1.0` from same control-center branch. 

I didn't update the README for `cp-all-in-one-kraft` since in it's README it's marked as deprecated, and it's basically same as `cp-all-in-one`
## Testing
#### cp-all-in-one

### Version 2.0.0

Command used
`docker compose up -d`

### Version correctly show in C3 UI
<img width="1727" alt="Screenshot 2025-06-20 at 12 15 45 AM" src="https://github.com/user-attachments/assets/0a3dfa1e-adc2-4cc0-aa22-f9eae0a60556" />

I have recently performed all the testing for 2.0.0 in previous PR.
https://github.com/confluentinc/cp-all-in-one/pull/212

### Version 2.1.0

Command used
`C3_VERSION=2.1.0 docker-compose up -d`
<img width="1727" alt="Screenshot 2025-06-20 at 12 53 19 AM" src="https://github.com/user-attachments/assets/52ae7bbd-6c9b-4974-aa49-2e7913485ccf" />

#### Alert Trigger and Metrics

https://github.com/user-attachments/assets/a2b52cc5-829f-4dc7-b01a-da06ed326553

<img width="481" alt="Screenshot 2025-06-20 at 12 57 36 AM" src="https://github.com/user-attachments/assets/73b66b54-4b44-44e2-b494-d3d1af2c306e" />



<!-- https://confluentinc.atlassian.net/browse/DEVX- -->

_What behavior does this PR change, and why?_


### Author Validation

_Describe the validation already done, or needs to be done, by the PR submitter._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->


### Reviewer Tasks

_Describe the tasks/validation that the PR submitter is requesting to be done by the reviewer._

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
<!-- - [ ] cp-all-in-one -->
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->
