### PR TITLE
Fix startup failure due to missing LOG_FILE environment variables

### DIFF
--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     environment:
       CONFIG_PATH: "/mnt/config"
       SHOULD_LOG_TO_FILE: false
+      LOG_FILE: "/dev/null"
 
   alertmanager:
     image: confluentinc/cp-enterprise-alertmanager:2.2.0
@@ -115,6 +116,7 @@ services:
     environment:
       CONFIG_PATH: "/mnt/config"
       SHOULD_LOG_TO_FILE: false
+      LOG_FILE: "/dev/null"
 
   control-center:
     image: confluentinc/cp-enterprise-control-center-next-gen:2.2.0


### PR DESCRIPTION
### Description 

Running `podman compose up -d` hung on the following services: schemaregistry, ksql-datagen. Tracking down the logs led to the following containers not starting: prometheus, alertmanager.

The following errors were returned from the prometheus and alertmanager containers.

```
/usr/bin/prometheus-start: line 88: LOG_FILE: unbound variable
```
```
/usr/bin/alertmanager-start: line 88: LOG_FILE: unbound variable
```

### Author Validation

Running `podman compose up -d` no longer hangs.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [x] cp-all-in-one
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->


### Reviewer Tasks

Run `podman compose up -d` for the `cp-all-in-one` folder an OSX (I ran on 15.6) before this fix and after this fix.

<!-- Uncomment any of the following that are required -->
<!-- - [ ] Documentation -->
 - [ ] cp-all-in-one
<!-- - [ ] cp-all-in-one-cloud -->
<!-- - [ ] cp-all-in-one-community -->
<!-- - [ ] cp-all-in-one-kraft -->
