### PR TITLE
Update Confluent Cloud banner UTM campaign parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Try Confluent Cloud - The Data Streaming Platform](https://images.ctfassets.net/8vofjvai1hpv/10bgcSfn5MzmvS4nNqr94J/af43dd2336e3f9e0c0ca4feef4398f6f/confluent-banner-v2.svg)](https://confluent.cloud/signup?utm_source=github&utm_medium=banner&utm_campaign=oss-repos&utm_term=cp-all-in-one)
+[![Try Confluent Cloud - The Data Streaming Platform](https://images.ctfassets.net/8vofjvai1hpv/10bgcSfn5MzmvS4nNqr94J/af43dd2336e3f9e0c0ca4feef4398f6f/confluent-banner-v2.svg)](https://confluent.cloud/signup?utm_source=github&utm_medium=banner&utm_campaign=tm.plg.cflt-oss-repos&utm_term=cp-all-in-one)
 
 # cp-all-in-one
 


### PR DESCRIPTION
## Summary
- Updates the UTM campaign parameter in the Confluent Cloud banner
- Changes from `utm_campaign=oss-repos` to `utm_campaign=tm.plg.cflt-oss-repos`

## Context
The original banner PR was merged with the old UTM parameter. This PR updates it to the correct tracking parameter.

## Changes
- Updated UTM campaign parameter in README.md banner link

## Testing
- [x] Banner link works correctly with new UTM parameter
- [x] No other changes to the README