### PR TITLE
Replacing the version to 2.5.0

### DIFF
--- a/cp-all-in-one-cloud/docker-compose.yml
+++ b/cp-all-in-one-cloud/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       KSQL_KSQL_CONNECT_URL: "http://connect:8083"
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center-next-gen:2.2.1
+    image: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
     hostname: control-center
     container_name: control-center
     ports:

--- a/cp-all-in-one-security/oauth/docker-compose.yml
+++ b/cp-all-in-one-security/oauth/docker-compose.yml
@@ -533,7 +533,7 @@ services:
         clientSecret="$KSQL_CLIENT_SECRET";   
 
   c3prometheus:
-    image: confluentinc/cp-enterprise-prometheus:2.2.1
+    image: confluentinc/cp-enterprise-prometheus:2.5.0
     hostname: cp-enterprise-prometheus
     container_name: c3prometheus
     volumes:
@@ -545,7 +545,7 @@ services:
       SHOULD_LOG_TO_FILE: false
 
   c3_alertmanager:
-    image: confluentinc/cp-enterprise-alertmanager:2.2.1
+    image: confluentinc/cp-enterprise-alertmanager:2.5.0
     hostname: cp-enterprise-alertmanager
     container_name: alertmanager
     depends_on:
@@ -559,7 +559,7 @@ services:
       SHOULD_LOG_TO_FILE: false
 
   control-center:
-    image: ${DOCKER_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:2.2.1
+    image: ${DOCKER_REGISTRY}confluentinc/cp-enterprise-control-center-next-gen:2.5.0
     hostname: control-center
     container_name: control-center
     healthcheck:

--- a/cp-all-in-one/docker-compose.yml
+++ b/cp-all-in-one/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
 
   prometheus:
-    image: confluentinc/cp-enterprise-prometheus:2.2.1
+    image: confluentinc/cp-enterprise-prometheus:2.5.0
     hostname: cp-enterprise-prometheus
     container_name: prometheus
     volumes:
@@ -103,7 +103,7 @@ services:
       SHOULD_LOG_TO_FILE: false
 
   alertmanager:
-    image: confluentinc/cp-enterprise-alertmanager:2.2.1
+    image: confluentinc/cp-enterprise-alertmanager:2.5.0
     hostname: cp-enterprise-alertmanager
     container_name: alertmanager
     depends_on:
@@ -117,7 +117,7 @@ services:
       SHOULD_LOG_TO_FILE: false
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center-next-gen:2.2.1
+    image: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
     hostname: control-center
     container_name: control-center
     depends_on:


### PR DESCRIPTION
## Summary
- Update C3++ (Control Center Next Gen) version to 2.5.0 in cp-all-in-one Docker Compose
- Update Prometheus version to 3.10.0 (bundled with C3++ 2.5.0)
- Update Alertmanager version to 0.31.1 (bundled with C3++ 2.5.0)
- CP version: 8.2.0

## Details
C3++ 2.5.0 is released alongside CP 8.2.0. This PR updates the cp-all-in-one Docker Compose configuration to use the 2.5.0 images.
